### PR TITLE
Avoid react event handler changing after contextSafe

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -6,7 +6,7 @@
 
 /// <reference path="../node_modules/gsap/types/index.d.ts"/>
 
-type ContextSafeFunc = (func: Function) => Function;
+type ContextSafeFunc = <T extends Function>(func: T) => T;
 type ContextFunc = (context: gsap.Context, contextSafe?: ContextSafeFunc) => Function | any | void;
 
 interface ReactRef {


### PR DESCRIPTION
Solve typescript error after using `contextSave`

```
Type 'Function' is not assignable to type '(e: MouseEvent<HTMLAnchorElement, MouseEvent>) => void'.
```